### PR TITLE
fix: Window shouldn't be activated from Activities overview

### DIFF
--- a/grand-theft-focus@zalckos.github.com/extension.js
+++ b/grand-theft-focus@zalckos.github.com/extension.js
@@ -13,7 +13,8 @@ GrandTheftFocus.prototype = {
     },
 
     _onWindowDemandsAttention: function(display, window) {
-        Main.activateWindow(window);
+        if (!Main.overview._shown)
+            Main.activateWindow(window);
     },
 
     destroy: function () {


### PR DESCRIPTION
Window activated from the overview during startup animation can freeze the Shell. This can happen when restarting Shell in X11 session.