### PR TITLE
Port to GNOME 45

### DIFF
--- a/grand-theft-focus@zalckos.github.com/extension.js
+++ b/grand-theft-focus@zalckos.github.com/extension.js
@@ -1,6 +1,8 @@
-const Main = imports.ui.main;
-const WindowAttentionHandler = imports.ui.windowAttentionHandler;
-const Shell = imports.gi.Shell;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as WindowAttentionHandler from 'resource:///org/gnome/shell/ui/windowAttentionHandler.js';
+import Shell from 'gi://Shell';
+
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 function GrandTheftFocus() {
     this._init();
@@ -22,15 +24,12 @@ GrandTheftFocus.prototype = {
     }
 }
 
-let grandtheftfocus;
+export default class GrandTheftExtension {
+    enable() {
+        this._grandtheftfocus = new GrandTheftFocus();
+    }
 
-function init() {
-}
-
-function enable() {
-    grandtheftfocus = new GrandTheftFocus();
-}
-
-function disable() {
-    grandtheftfocus = null;
+    disable() {
+        this._grandtheftfocus = null;
+    }
 }

--- a/grand-theft-focus@zalckos.github.com/metadata.json
+++ b/grand-theft-focus@zalckos.github.com/metadata.json
@@ -4,11 +4,6 @@
   "license": "GPLv3",
   "name": "Grand Theft Focus",
   "shell-version": [
-    "40",
-    "41",
-    "42",
-    "43",
-    "44",
     "45"
   ],
   "url": "https://github.com/zalckos/GrandTheftFocus",


### PR DESCRIPTION
GNOME 45 has a large number of changes, but this extension is only affected by the ones that affect every extension.

GNOME now uses ESM imports, and the extension must export a default class. This wasn't required by GNOME 45 alpha, but GNOME 45 beta and onwards requires it, so a simple metadata change won't manage for this version.

Unfortunately, this means that every version pre-GNOME 45 has to be dropped, as ESM imports can't be supported at the same time as the old style imports.

Tested on Fedora Rawhide, works perfectly :)