### PR TITLE
Add GNOME 46 support to metadata

### DIFF
--- a/grand-theft-focus@zalckos.github.com/metadata.json
+++ b/grand-theft-focus@zalckos.github.com/metadata.json
@@ -4,7 +4,8 @@
   "license": "GPLv3",
   "name": "Grand Theft Focus",
   "shell-version": [
-    "45"
+    "45",
+    "46"
   ],
   "url": "https://github.com/zalckos/GrandTheftFocus",
   "uuid": "grand-theft-focus@zalckos.github.com",


### PR DESCRIPTION
Seems to be working on my system, looks fine according to the porting guide too (Debian Experimental)