### PR TITLE
Add support for GNOME 47 to metadata

### DIFF
--- a/grand-theft-focus@zalckos.github.com/metadata.json
+++ b/grand-theft-focus@zalckos.github.com/metadata.json
@@ -5,7 +5,8 @@
   "name": "Grand Theft Focus",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/zalckos/GrandTheftFocus",
   "uuid": "grand-theft-focus@zalckos.github.com",


### PR DESCRIPTION
Working on GNOME 47, no changes required