### PR TITLE
Add GNOME 48 to metadata

### DIFF
--- a/grand-theft-focus@zalckos.github.com/metadata.json
+++ b/grand-theft-focus@zalckos.github.com/metadata.json
@@ -6,7 +6,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/zalckos/GrandTheftFocus",
   "uuid": "grand-theft-focus@zalckos.github.com",


### PR DESCRIPTION
Working without any code changes, tested with GNOME OS Nightly