### PR TITLE
Support for GNOME 50

### DIFF
--- a/grand-theft-focus@zalckos.github.com/metadata.json
+++ b/grand-theft-focus@zalckos.github.com/metadata.json
@@ -8,7 +8,8 @@
     "46",
     "47",
     "48",
-    "49"
+    "49",
+    "50"
   ],
   "url": "https://github.com/zalckos/GrandTheftFocus",
   "uuid": "grand-theft-focus@zalckos.github.com",


### PR DESCRIPTION
Preparing for GNOME 50.0 release on March 18.

Tested on GNOME 50.beta and 50.rc.