### PR TITLE
Fix extension not properly disabled

### DIFF
--- a/grand-theft-focus@zalckos.github.com/extension.js
+++ b/grand-theft-focus@zalckos.github.com/extension.js
@@ -1,35 +1,18 @@
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-import * as WindowAttentionHandler from 'resource:///org/gnome/shell/ui/windowAttentionHandler.js';
-import Shell from 'gi://Shell';
 
-import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
-
-function GrandTheftFocus() {
-    this._init();
-}
-
-GrandTheftFocus.prototype = {
-    _init : function() {
-        this._tracker = Shell.WindowTracker.get_default();
-        this._handlerid = global.display.connect('window-demands-attention', this._onWindowDemandsAttention.bind(this));
-    },
-
-    _onWindowDemandsAttention: function(display, window) {
-        if (!Main.overview._shown)
-            Main.activateWindow(window);
-    },
-
-    destroy: function () {
-        global.display.disconnect(this._handlerid);
+function onWindowDemandsAttention(display, window) {
+    if (!Main.overview._shown) {
+        Main.activateWindow(window);
     }
 }
 
 export default class GrandTheftExtension {
     enable() {
-        this._grandtheftfocus = new GrandTheftFocus();
+        this._handlerid = global.display.connect('window-demands-attention', onWindowDemandsAttention);
     }
 
     disable() {
-        this._grandtheftfocus = null;
+        global.display.disconnect(this._handlerid);
+        delete this._handlerid;
     }
 }


### PR DESCRIPTION
Instead of relying on `destroy` being called by the GC, just inline the required methods directly. Also simplifies the implementation and removes unused code. Fixes the issue mentioned in https://github.com/zalckos/GrandTheftFocus/issues/9#issuecomment-2273463249.

https://github.com/user-attachments/assets/5cb375ef-fe66-474d-9d04-284cc16cce5d

